### PR TITLE
Please add Proc object matching

### DIFF
--- a/lib/rubydns/server.rb
+++ b/lib/rubydns/server.rb
@@ -144,6 +144,16 @@ module RubyDNS
 					else
 						@logger.debug "Query #{name} failed to match against #{pattern[0]}"
 					end
+				when Proc
+					if pattern[0].call(name)
+						@logger.debug "Query #{name} matched #{pattern[0]}"
+						if rule[1].call(*args)
+							@logger.debug "Rule returned successfully"
+							return
+						end
+					else
+						@logger.debug "Query #{name} failed to match against #{pattern[0]}"
+					end
 				end
 			end
 


### PR DESCRIPTION
Hi,
## I wrote Proc object matching patch.

ex)
m = lambda do |name|
  name =~ /dev.mydomain.org/
end

RubyDNS::run_server(:listen => [[:udp, "0.0.0.0", 5300]]) do
    match(m, :A) do |transaction|
        transaction.respond!("10.0.0.80")
##     end

Please add this patch.
