### PR TITLE
Allow block to modify the response in a transaction

### DIFF
--- a/lib/rubydns/transaction.rb
+++ b/lib/rubydns/transaction.rb
@@ -4,39 +4,39 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 module RubyDNS
-	
+
 	# Turn a symbol or string name into a resource class. For example,
 	# convert <tt>:A</tt> into <tt>Resolv::DNS::Resource::IN::A</tt>
-	# Provide a second argument (top) to specify a namespace where 
+	# Provide a second argument (top) to specify a namespace where
 	# klass should be resolved, e.g. <tt>Resolv::DNS::Resource::IN</tt>.
 	def self.lookup_resource_class(klass, top = nil)
 		return nil if klass == nil
-		
+
 		if Symbol === klass
 			klass = klass.to_s
 		end
-		
+
 		if String === klass
 			top ||= Resolv::DNS::Resource::IN
 			klass = self.find_constant(top, klass.split("::"))
 		end
-		
+
 		return klass
 	end
-	
+
 	def self.constantize(names)
 		top = Object
-	
+
 		names.each do |name|
 			if top.const_defined?(name)
 				top = top.const_get(name)
@@ -44,24 +44,24 @@ module RubyDNS
 				return nil
 			end
 		end
-	
+
 		top
 	end
 
 	def self.find_constant(top, klass)
 		names = top.name.split("::")
-	
+
 		while names.size
 			object = self.constantize(names + klass)
-		
+
 			return object if object
-		
+
 			names.pop
 		end
-	
+
 		return nil
 	end
-	
+
 	# This class provides all details of a single DNS question and answer. This
 	# is used by the DSL to provide DNS related functionality.
 	class Transaction
@@ -71,20 +71,20 @@ module RubyDNS
 			@question = question
 			@resource_class = resource_class
 			@answer = answer
-			
+
 			@question_appended = false
 		end
 
 		# The resource_class that was requested. This is typically used to generate a
 		# response.
 		attr :resource_class
-		
+
 		# The incoming query which is a set of questions.
 		attr :query
-		
+
 		# The question that this transaction represents.
 		attr :question
-		
+
 		# The current full answer to the incoming query.
 		attr :answer
 
@@ -92,14 +92,14 @@ module RubyDNS
 		def record_type
 			@resource_class.name.split("::").last
 		end
-		
+
 		# Tries to find a resource class within the current resource category, which is
 		# typically (but not always) <tt>IN</tt>. Uses the requested resource class as
 		# a starting point.
 		def lookup_resource_class(klass)
 			return RubyDNS::lookup_resource_class(klass, @resource_class)
 		end
-		
+
 		# Return the name of the question, which is typically the requested hostname.
 		def name
 			@question.to_s
@@ -134,9 +134,9 @@ module RubyDNS
 
 				if reply
 					if block_given?
-						yield(reply, reply_name)
+						ret = yield(reply, reply_name)
+						reply = ret if ret.is_a?(Resolv::DNS::Message)
 					end
-
 					@answer.merge!(reply)
 				else
 					failure!(:NXDomain)
@@ -162,30 +162,30 @@ module RubyDNS
 		# This function instantiates the resource class with the supplied arguments, and
 		# then passes it to <tt>append!</tt>.
 		#
-		# See <tt>Resolv::DNS::Resource</tt> for more information about the various 
-		# <tt>resource_class</tt>s available. 
+		# See <tt>Resolv::DNS::Resource</tt> for more information about the various
+		# <tt>resource_class</tt>s available.
 		# http://www.ruby-doc.org/stdlib/libdoc/resolv/rdoc/index.html
 		def respond! (*data)
 			options = data.last.kind_of?(Hash) ? data.pop : {}
 			resource_class = lookup_resource_class(options[:resource_class]) || @resource_class
-			
+
 			if resource_class == nil
 				raise ArgumentError, "Could not instantiate resource #{resource_class}!"
 			end
-			
+
 			@server.logger.info "Resource class: #{resource_class.inspect}"
 			resource = resource_class.new(*data)
 			@server.logger.info "Resource: #{resource.inspect}"
-			
+
 			append!(resource, options)
 		end
 
-		# Append a given set of resources to the answer. The last argument can 
+		# Append a given set of resources to the answer. The last argument can
 		# optionally be a hash of options.
-		# 
+		#
 		# <tt>options[:ttl]</tt>:: Specify the TTL for the resource
 		# <tt>options[:name]</tt>:: Override the name (question) of the response.
-		# 
+		#
 		# This function can be used to supply multiple responses to a given question.
 		# For example, each argument is expected to be an instantiated resource from
 		# <tt>Resolv::DNS::Resource</tt> module.


### PR DESCRIPTION
Example:

``` ruby
t.passthrough!($OpenDNS) do |reply, reply_name|
       reply.answer.delete_if do |ans| # Reject any private addresses of OpenDNS
           ans[2].is_a?(Resolv::DNS::Resource::IN::A) ? rejected?(ans[2].address.to_s) : false
       end
       reply
end
```

If the block returns an object which isn't of type Resolv::DNS::Message, simplify ignore it.
