### PR TITLE
Change log level of add_answer to debug

### DIFF
--- a/lib/rubydns/transaction.rb
+++ b/lib/rubydns/transaction.rb
@@ -214,7 +214,7 @@ module RubyDNS
 			options[:name] ||= @question.to_s + "."
 
 			resources.each do |resource|
-				@server.logger.info "add_answer: #{resource.inspect} #{resource.class::TypeValue} #{resource.class::ClassValue}"
+				@server.logger.debug "add_answer: #{resource.inspect} #{resource.class::TypeValue} #{resource.class::ClassValue}"
 				@answer.add_answer(options[:name], options[:ttl], resource)
 			end
 


### PR DESCRIPTION
I want to use rubydns with info logger level in production environment. But many messages of add_answer are outputed. So I am glad when you merge this change.
