### PR TITLE
Bugfix for https://github.com/ioquatix/rubydns/issues/5

### DIFF
--- a/lib/rubydns/resolv.rb
+++ b/lib/rubydns/resolv.rb
@@ -27,7 +27,7 @@ class Resolv
 		# modification/reinterpretation.
 		def query(name, typeclass)
 			lazy_initialize
-			requester = make_requester
+			requester = make_udp_requester
 			senders = {}
 			begin
 				@config.resolv(name) {|candidate, tout, nameserver|


### PR DESCRIPTION
The code is still relying on a private API, and could therefore break again in the future.

A cleaner patch would be to only use documented APIs.
