### PR TITLE
Fix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,11 @@ end
 run
 ```
 Start the server using `rvmsudo ./test.rb`. You can then test it using dig:
-    $ dig @localhost test1.mydomain.org
-    $ dig @localhost dev.mydomain.org
-    $ dig @localhost google.com
+```
+$ dig @localhost test1.mydomain.org
+$ dig @localhost dev.mydomain.org
+$ dig @localhost google.com
+```
 
 ## Compatibility
 


### PR DESCRIPTION
I was trying to run the example from the [usage](https://github.com/ioquatix/rubydns/blob/master/README.md#usage) section of rubydns' README and wasn't able to get it to run without a few changes. I added some code there while also adding syntax highlighting to the ruby code blocks in the README.
