### PR TITLE
Fix potential null exception on TCP requests

### DIFF
--- a/lib/rubydns/resolver.rb
+++ b/lib/rubydns/resolver.rb
@@ -223,7 +223,7 @@ module RubyDNS
 					end
 
 					# If we have received more data than expected, should this be an error?
-					if @buffer.size >= (@length + 2)
+					if !@length.nil? && @buffer.size >= (@length + 2)
 						data = @buffer.string.byteslice(2, @length)
 						
 						message = RubyDNS::decode_message(data)


### PR DESCRIPTION
I was often getting errors when using the System::nameservers
(~/dev/ruby_gem/rubydns/lib/rubydns/resolver.rb:226:in `receive_data': undefined method`+' for nil:NilClass (NoMethodError))
