### PR TITLE
Add a RuboCop policy file that preserves leading tabs.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,6 @@
+Style/Tab:
+  Enabled: false
+Style/IndentationConsistency:
+  Enabled: false
+Style/IndentationWidth:
+  Enabled: false


### PR DESCRIPTION
This should make it easy to run RuboCop without replacing leading tabs.
