### PR TITLE
fix ruby warning

### DIFF
--- a/lib/rubydns/server.rb
+++ b/lib/rubydns/server.rb
@@ -266,7 +266,7 @@ module RubyDNS
 			@otherwise = nil
 			
 			if block_given?
-				instance_eval &block
+				instance_eval(&block)
 			end
 		end
 


### PR DESCRIPTION
warning: `&' interpreted as argument prefix