### PR TITLE
Specify `Celluloid::IO::UDPSocket#recvfrom` to `flags=0`

### DIFF
--- a/lib/rubydns/handler.rb
+++ b/lib/rubydns/handler.rb
@@ -112,7 +112,7 @@ module RubyDNS
 		def handle_connection
 			# @logger.debug "Waiting for incoming UDP packet #{@socket.inspect}..."
 			
-			input_data, (_, remote_port, remote_host) = @socket.recvfrom(UDP_TRUNCATION_SIZE)
+			input_data, (_, remote_port, remote_host) = @socket.recvfrom(UDP_TRUNCATION_SIZE, 0)
 			
 			async.respond(input_data, remote_host, remote_port)
 		rescue IOError => error

--- a/lib/rubydns/resolver.rb
+++ b/lib/rubydns/resolver.rb
@@ -222,7 +222,7 @@ module RubyDNS
 			
 			socket.send(request.packet, 0, host, port)
 			
-			data, (_, remote_port) = socket.recvfrom(UDP_TRUNCATION_SIZE)
+			data, (_, remote_port) = socket.recvfrom(UDP_TRUNCATION_SIZE, 0)
 			# Need to check host, otherwise security issue.
 			
 			# May indicate some kind of spoofing attack:

--- a/spec/rubydns/resolver_spec.rb
+++ b/spec/rubydns/resolver_spec.rb
@@ -41,7 +41,7 @@ module RubyDNS::ResolverSpec
 			end
 	
 			def run
-				data, (_, port, host) = @socket.recvfrom(1024)
+				data, (_, port, host) = @socket.recvfrom(1024, 0)
 		
 				@socket.send("Foobar", 0, host, port)
 			end


### PR DESCRIPTION
This is a workaround for behavior change against Celluloid::IO with Ruby 2.3.
see also: https://github.com/celluloid/celluloid-io/pull/163