### PR TITLE
Actor crashed

### DIFF
--- a/lib/rubydns/handler.rb
+++ b/lib/rubydns/handler.rb
@@ -107,6 +107,8 @@ module RubyDNS
 			@logger.warn "<> UDP session ended prematurely: #{error.inspect}!"
 		rescue DecodeError
 			@logger.warn "<> Could not decode incoming UDP data!"
+		rescue Exception => error
+		        @logger.error error.inspect
 		end
 		
 		def handle_connection


### PR DESCRIPTION
I have random problem with crashed actors, because of unhandled exceptions.

E, [2016-01-10T10:17:14.710791 #10236] ERROR -- : Actor crashed!
Errno::EINVAL: Invalid argument - sendto(2) for "90.161.29.45" port 0
        /usr/local/rvm/gems/ruby-2.2.1/gems/rubydns-1.0.3/lib/rubydns/handler.rb:103:in `respond'
        /usr/local/rvm/gems/ruby-2.2.1/gems/celluloid-0.16.0/lib/celluloid/calls.rb:26:in`public_send'
        /usr/local/rvm/gems/ruby-2.2.1/gems/celluloid-0.16.0/lib/celluloid/calls.rb:26:in `dispatch'
        /usr/local/rvm/gems/ruby-2.2.1/gems/celluloid-0.16.0/lib/celluloid/calls.rb:122:in`dispatch'
        /usr/local/rvm/gems/ruby-2.2.1/gems/celluloid-0.16.0/lib/celluloid/cell.rb:60:in `block in invoke'
        /usr/local/rvm/gems/ruby-2.2.1/gems/celluloid-0.16.0/lib/celluloid/cell.rb:71:in`block in task'
        /usr/local/rvm/gems/ruby-2.2.1/gems/celluloid-0.16.0/lib/celluloid/actor.rb:357:in `block in task'
        /usr/local/rvm/gems/ruby-2.2.1/gems/celluloid-0.16.0/lib/celluloid/tasks.rb:57:in`block in initialize'
        /usr/local/rvm/gems/ruby-2.2.1/gems/celluloid-0.16.0/lib/celluloid/tasks/task_fiber.rb:15:in `block in create'

Or

E, [2016-01-11T07:27:11.089670 #23727] ERROR -- : Actor crashed!
Errno::EPERM: Operation not permitted - sendto(2) for "185.53.8.39" port 38694
        /usr/local/rvm/gems/ruby-2.2.1/gems/rubydns-1.0.3/lib/rubydns/handler.rb:103:in `respond'
...

after that daemon still works but not listening any more on the port, why supervisor doesn't restart actor?
If you want repeat problem, add rule on dns server :
iptables -I OUTPUT -d [client_ip] -j DROP
after that try to resolve domain from client_ip through this DNS servers
