### PR TITLE
fix for flakey-dns.rb example

### DIFF
--- a/examples/flakey-dns.rb
+++ b/examples/flakey-dns.rb
@@ -49,8 +49,8 @@ class FlakeyDNS < Process::Daemon
 					logger.info 'Dropping domain MICROSOFT...'
 					transaction.fail!(:NXDomain)
 				else
-					# Pass the request to the otherwise handler
-					false
+					logger.info 'Passing DNS request upstream...'
+					transaction.passthrough!(fallback_resolver_supervisor.actors.first)
 				end
 			end
 


### PR DESCRIPTION
Ruby noob. Made a simple edit/copy to fix issue #63. Given that each block is written for a distinct dns query, the otherwise block is a discrete entity separate from the microsoft regex.   